### PR TITLE
Enable build on z Systems (s390x)

### DIFF
--- a/include/openssl/base.h
+++ b/include/openssl/base.h
@@ -90,6 +90,9 @@ extern "C" {
 #elif defined(__pnacl__)
 #define OPENSSL_32_BIT
 #define OPENSSL_PNACL
+#elif defined(__s390x__)
+#define OPENSSL_64_BIT
+#define OPENSSL_S390X
 #else
 #error "Unknown target CPU"
 #endif


### PR DESCRIPTION
Add the s390x architecture. This is the 1st step that will enable the build. The next step is to optimize the algorithms as the z processor has hardware support for most if not all the ciphers/hashes used by boringSSL.
