### PR TITLE
Unbreak secp256r1 on big endian by disabling the optimized path

### DIFF
--- a/crypto/ec/ec.c
+++ b/crypto/ec/ec.c
@@ -223,7 +223,7 @@ static const struct curve_data P521 = {
 /* MSan appears to have a bug that causes code to be miscompiled in opt mode.
  * While that is being looked at, don't run the uint128_t code under MSan. */
 #if defined(OPENSSL_64_BIT) && !defined(OPENSSL_WINDOWS) && \
-    !defined(MEMORY_SANITIZER)
+    !defined(MEMORY_SANITIZER) && __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__
 #define BORINGSSL_USE_INT128_CODE
 #endif
 


### PR DESCRIPTION
Neale seems to have tried to fix this for s390x, but it's still not working there nor on ppc64. We can just fall back to a less optimized implementation however, which does work fine.

Upstream OpenSSL, LibreSSL, and BoringSSL have diverged heavily from this implementation anyways; so we'd need to rework support anyways.

Fixes #8.