### PR TITLE
Reduce build dependencies when building with OPENSSL_NO_ASM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ elseif(MSVC)
               # (performance warning)
       "C4820" # 'bytes' bytes padding added after construct 'member_name'
       "C5027" # move assignment operator was implicitly defined as deleted
+      "C5045" # compiler will insert Spectre mitigation for memory load
+              # if /Qspectre switch specified
       )
   set(MSVC_LEVEL4_WARNINGS_LIST
       # See https://connect.microsoft.com/VisualStudio/feedback/details/1217660/warning-c4265-when-using-functional-header

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,14 @@ enable_language(CXX)
 if(ANDROID)
   # Android-NDK CMake files reconfigure the path and so Go and Perl won't be
   # found. However, ninja will still find them in $PATH if we just name them.
-  set(PERL_EXECUTABLE "perl")
+  if(NOT OPENSSL_NO_ASM)
+    set(PERL_EXECUTABLE "perl")
+  endif()
   # set(GO_EXECUTABLE "go")
 else()
-  find_package(Perl REQUIRED)
+  if(NOT OPENSSL_NO_ASM)
+    find_package(Perl REQUIRED)
+  endif()
   # find_program(GO_EXECUTABLE go)
 endif()
 
@@ -185,7 +189,9 @@ if (ANDROID AND ${ARCH} STREQUAL "arm")
   # The Android-NDK CMake files somehow fail to set the -march flag for
   # assembly files. Without this flag, the compiler believes that it's
   # building for ARMv5.
-  set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -march=${CMAKE_SYSTEM_PROCESSOR}")
+  if (NOT OPENSSL_NO_ASM)
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -march=${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
 endif()
 
 # if (${ARCH} STREQUAL "x86" AND APPLE)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -1,58 +1,64 @@
 include_directories(../include)
 
-if(APPLE)
-  if (${ARCH} STREQUAL "x86")
-    set(PERLASM_FLAGS "-fPIC -DOPENSSL_IA32_SSE2")
-  endif()
-  set(PERLASM_STYLE macosx)
-  set(ASM_EXT S)
-  enable_language(ASM)
-elseif(UNIX)
-  if (${ARCH} STREQUAL "aarch64")
-    # The "armx" Perl scripts look for "64" in the style argument
-    # in order to decide whether to generate 32- or 64-bit asm.
-    set(PERLASM_STYLE linux64)
-  elseif (${ARCH} STREQUAL "arm")
-    set(PERLASM_STYLE linux32)
-  elseif (${ARCH} STREQUAL "x86")
-    set(PERLASM_FLAGS "-fPIC -DOPENSSL_IA32_SSE2")
-    set(PERLASM_STYLE elf)
+if(NOT OPENSSL_NO_ASM)
+  if(APPLE)
+    if (${ARCH} STREQUAL "x86")
+      set(PERLASM_FLAGS "-fPIC -DOPENSSL_IA32_SSE2")
+    endif()
+    set(PERLASM_STYLE macosx)
+    set(ASM_EXT S)
+    enable_language(ASM)
+  elseif(UNIX)
+    if (${ARCH} STREQUAL "aarch64")
+      # The "armx" Perl scripts look for "64" in the style argument
+      # in order to decide whether to generate 32- or 64-bit asm.
+      set(PERLASM_STYLE linux64)
+    elseif (${ARCH} STREQUAL "arm")
+      set(PERLASM_STYLE linux32)
+    elseif (${ARCH} STREQUAL "x86")
+      set(PERLASM_FLAGS "-fPIC -DOPENSSL_IA32_SSE2")
+      set(PERLASM_STYLE elf)
+    else()
+      set(PERLASM_STYLE elf)
+    endif()
+    set(ASM_EXT S)
+    enable_language(ASM)
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")
   else()
-    set(PERLASM_STYLE elf)
+    if (CMAKE_CL_64)
+      message("Using nasm")
+      set(PERLASM_STYLE nasm)
+    else()
+      message("Using win32n")
+      set(PERLASM_STYLE win32n)
+      set(PERLASM_FLAGS "-DOPENSSL_IA32_SSE2")
+    endif()
+
+    # On Windows, we use the NASM output, specifically built with Yasm.
+    set(ASM_EXT asm)
+    enable_language(ASM_NASM)
   endif()
-  set(ASM_EXT S)
-  enable_language(ASM)
-  set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")
+
+  function(perlasm dest src)
+    add_custom_command(
+      OUTPUT ${dest}
+      COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${src} ${PERLASM_STYLE} ${PERLASM_FLAGS} ${ARGN} > ${dest}
+      DEPENDS
+      ${src}
+      ${PROJECT_SOURCE_DIR}/crypto/perlasm/arm-xlate.pl
+      ${PROJECT_SOURCE_DIR}/crypto/perlasm/x86_64-xlate.pl
+      ${PROJECT_SOURCE_DIR}/crypto/perlasm/x86asm.pl
+      ${PROJECT_SOURCE_DIR}/crypto/perlasm/x86gas.pl
+      ${PROJECT_SOURCE_DIR}/crypto/perlasm/x86masm.pl
+      ${PROJECT_SOURCE_DIR}/crypto/perlasm/x86nasm.pl
+      WORKING_DIRECTORY .
+    )
+  endfunction()
 else()
-  if (CMAKE_CL_64)
-    message("Using nasm")
-    set(PERLASM_STYLE nasm)
-  else()
-    message("Using win32n")
-    set(PERLASM_STYLE win32n)
-    set(PERLASM_FLAGS "-DOPENSSL_IA32_SSE2")
-  endif()
-
-  # On Windows, we use the NASM output, specifically built with Yasm.
-  set(ASM_EXT asm)
-  enable_language(ASM_NASM)
+  function(perlasm dest src)
+    # Disabled since OPENSSL_NO_ASM has been defined.
+  endfunction()
 endif()
-
-function(perlasm dest src)
-  add_custom_command(
-    OUTPUT ${dest}
-    COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${src} ${PERLASM_STYLE} ${PERLASM_FLAGS} ${ARGN} > ${dest}
-    DEPENDS
-    ${src}
-    ${PROJECT_SOURCE_DIR}/crypto/perlasm/arm-xlate.pl
-    ${PROJECT_SOURCE_DIR}/crypto/perlasm/x86_64-xlate.pl
-    ${PROJECT_SOURCE_DIR}/crypto/perlasm/x86asm.pl
-    ${PROJECT_SOURCE_DIR}/crypto/perlasm/x86gas.pl
-    ${PROJECT_SOURCE_DIR}/crypto/perlasm/x86masm.pl
-    ${PROJECT_SOURCE_DIR}/crypto/perlasm/x86nasm.pl
-    WORKING_DIRECTORY .
-  )
-endfunction()
 
 # Level 0.1 - depends on nothing outside this set.
 add_subdirectory(stack)


### PR DESCRIPTION
Windows is currently building with OPENSSL_NO_ASM on cygwin/mingw/msvc. Current cmake files still includes dependencies only needed when building with ASM support, this PR reduce needed  dependencies when building with OPENSSL_NO_ASM (not requiring perl, yasm, ninja). In the long run we will get all dependencies working on all Windows builds as well, but until that is done, this enhancements to the build scripts will be beneficial.
