### PR TITLE
[ANDROID] Fix another Android toolchain issue with crypto assembly

### DIFF
--- a/crypto/aes/asm/aesv8-armx.pl
+++ b/crypto/aes/asm/aesv8-armx.pl
@@ -51,7 +51,7 @@ $code=<<___;
 .text
 ___
 $code.=<<___ if ($flavour =~ /64/);
-#if !defined(__clang__)
+#if defined(ANDROID) || !defined(__clang__)
 .arch  armv8-a+crypto
 #endif
 ___

--- a/crypto/modes/asm/ghashv8-armx.pl
+++ b/crypto/modes/asm/ghashv8-armx.pl
@@ -59,7 +59,7 @@ $code=<<___;
 .text
 ___
 $code.=<<___ if ($flavour =~ /64/);
-#if !defined(__clang__)
+#if defined(ANDROID) || !defined(__clang__)
 .arch  armv8-a+crypto
 #endif
 ___


### PR DESCRIPTION
Some armv8 assembly sources contain the following directive:

    #if !defined(__clang__)
       .arch  armv8-a+crypto
     #endif

Which supposedly works using desktop (probably Apple) versions of Clang but, for
some reason, fails to build with Android NDK's clang - it appears the directive
is necessary for that compiler to properly compile the assembly source.

Make sure we do not exclude the directive when building for Android.
