### PR TITLE
Another Android+clang assembly build fix

### DIFF
--- a/crypto/aes/asm/aesv8-armx.pl
+++ b/crypto/aes/asm/aesv8-armx.pl
@@ -52,7 +52,7 @@ $code=<<___;
 ___
 $code.=<<___ if ($flavour =~ /64/);
 #if defined(ANDROID) || !defined(__clang__)
-.arch  armv8-a+crypto
+.arch  armv8-a+crypto,+neon
 #endif
 ___
 $code.=".arch	armv7-a\n.fpu	neon\n.code	32\n"	if ($flavour !~ /64/);

--- a/crypto/modes/asm/ghashv8-armx.pl
+++ b/crypto/modes/asm/ghashv8-armx.pl
@@ -60,7 +60,7 @@ $code=<<___;
 ___
 $code.=<<___ if ($flavour =~ /64/);
 #if defined(ANDROID) || !defined(__clang__)
-.arch  armv8-a+crypto
+.arch  armv8-a+crypto,+neon
 #endif
 ___
 $code.=".fpu	neon\n.code	32\n"	if ($flavour !~ /64/);


### PR DESCRIPTION
This time for clang from an older NDK (14b) which not only needs the previous
fix to enable the crypto extensions but it also needs NEON to be explicitly
enabled in order to avoid errors similar to:

    ghashv8-armx.S:14:2: error: instruction requires: neon
     movi v19.16b,#0xe1