### PR TITLE
[Android] Fixing the previous clang fix

### DIFF
--- a/crypto/aes/asm/aesv8-armx.pl
+++ b/crypto/aes/asm/aesv8-armx.pl
@@ -51,8 +51,14 @@ $code=<<___;
 .text
 ___
 $code.=<<___ if ($flavour =~ /64/);
-#if defined(ANDROID) || !defined(__clang__)
-.arch  armv8-a+crypto,+neon
+#if !defined(__clang__)
+.arch   armv8-a+crypto
+#elif defined(ANDROID) && defined(__clang__) 
+#if __clang_major__ > 3
+.arch   armv8-a+crypto
+#else
+.arch   armv8-a+crypto,+neon
+#endif
 #endif
 ___
 $code.=".arch	armv7-a\n.fpu	neon\n.code	32\n"	if ($flavour !~ /64/);

--- a/crypto/modes/asm/ghashv8-armx.pl
+++ b/crypto/modes/asm/ghashv8-armx.pl
@@ -59,8 +59,14 @@ $code=<<___;
 .text
 ___
 $code.=<<___ if ($flavour =~ /64/);
-#if defined(ANDROID) || !defined(__clang__)
-.arch  armv8-a+crypto,+neon
+#if !defined(__clang__)
+.arch   armv8-a+crypto
+#elif defined(ANDROID) && defined(__clang__) 
+#if __clang_major__ > 3
+.arch   armv8-a+crypto
+#else
+.arch   armv8-a+crypto,+neon
+#endif
 #endif
 ___
 $code.=".fpu	neon\n.code	32\n"	if ($flavour !~ /64/);


### PR DESCRIPTION
 Turns out that `+neon` architecture extension is required (and accepted) only by
 the (buggy) clang 3.x in NDK r14 while both gcc and clang > 3 error out when
 they see `+neon`... So, the magic incantation contained in this commit *appears*
 to work for all of them. Tested manually with clang 3.x, clang 7.x, gcc
 7.x (aarch64 cross-compiler on Linux) and gcc 8.x (aarch64 cross-compiler on
 Linux)
