### PR TITLE
Fix X509_LOOKUP_add_dir to work with Windows paths.

### DIFF
--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -68,6 +68,12 @@
 
 #include "../internal.h"
 
+#ifdef OPENSSL_WINDOWS
+#define LIST_SEPARATOR_CHAR ';'
+#else
+#define LIST_SEPARATOR_CHAR ':'
+#endif
+
 typedef struct lookup_dir_hashes_st {
     unsigned long hash;
     int suffix;
@@ -203,7 +209,7 @@ static int add_cert_dir(BY_DIR *ctx, const char *dir, int type)
     s = dir;
     p = s;
     do {
-        if ((*p == ':') || (*p == '\0')) {
+        if ((*p == LIST_SEPARATOR_CHAR) || (*p == '\0')) {
             BY_DIR_ENTRY *ent;
             ss = s;
             s = p + 1;

--- a/crypto/x509/x509_def.c
+++ b/crypto/x509/x509_def.c
@@ -59,7 +59,17 @@
 
 /* TODO(fork): cleanup */
 
+#ifdef OPENSSL_WINDOWS
+/* OpenSSL defaults on Windows. */
+#if _WIN64
+#define OPENSSLDIR "C:\\Program Files\\Common Files\\SSL"
+#else
+#define OPENSSLDIR "C:\\Program Files (x86)\\Common Files\\SSL"
+#endif
+#else
 #define OPENSSLDIR "/etc/ssl"
+#endif
+
 #define X509_CERT_AREA          OPENSSLDIR
 #define X509_CERT_DIR           OPENSSLDIR "/certs"
 #define X509_CERT_FILE          OPENSSLDIR "/cert.pem"


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/14311.

Current boringssl implementation uses ':' as path list separator, meaning that Windows paths doesn't work. By default our user and machine store paths on Windows are located here:

Default User Store Path:
C:\Users\[current user]\AppData\Roaming\.mono\new-certs\Trust

Default Machine Store Path:
C:\ProgramData\.mono\new-certs\Trust

Fix is to use (as done in openssl repro) separators depending on platform.

The default OPENSSLDIR was also not accounting for none Unix platforms in boringssl repro, this sets the default values on Windows as you get when running configure in openssl.
